### PR TITLE
removing before 2019 openAQ measurements

### DIFF
--- a/data/Data extraction & wrangling.ipynb
+++ b/data/Data extraction & wrangling.ipynb
@@ -621,11 +621,16 @@
     }
    ],
    "source": [
-    "cols =[\"datetime\", \"pm25\", \"type\", \"sensor\", \"station_id\", \"x\", \"y\"]\n",
-    "#df_PM25.columns.tolist()\n",
     "df_PM25 = df_PM25[geoFilter]\n",
     "#df_PM25[cols].head()\n",
-    "len(df_PM25[cols])"
+    "len(df_PM25)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## For v1 we keep only 2019 records"
    ]
   },
   {
@@ -634,20 +639,9 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "105054 records are now 243781\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "count     243781\n",
-       "unique         2\n",
-       "top       AirNow\n",
-       "freq      138727\n",
-       "Name: type, dtype: object"
+       "47570"
       ]
      },
      "execution_count": 8,
@@ -656,6 +650,50 @@
     }
    ],
    "source": [
+    "dateFilter = df_PM25.datetime.str.startswith(\"2019\")\n",
+    "df_PM25 = df_PM25[dateFilter]\n",
+    "#df_PM25[cols].head()\n",
+    "len(df_PM25)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Save record to bigtable along purpleair ones keeping only same columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "105054 records are now 152624\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "count        152624\n",
+       "unique            2\n",
+       "top       PurpleAir\n",
+       "freq         105054\n",
+       "Name: type, dtype: object"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cols =[\"datetime\", \"pm25\", \"type\", \"sensor\", \"station_id\", \"x\", \"y\"]\n",
+    "\n",
+    "\n",
     "df_bigtable = pd.read_csv(\"bigtable.csv\")\n",
     "nb = len(df_bigtable)\n",
     "df_bigtable = df_bigtable.append(df_PM25[cols])\n",
@@ -665,7 +703,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -699,7 +737,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -732,7 +770,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -752,14 +790,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "nb ground station measurement : 243781\n",
+      "nb ground station measurement : 152624\n",
       "nb meteo : 14449\n"
      ]
     },
@@ -888,7 +926,7 @@
        "4  001609,5,N,5  99999,9 2019-01-01 00:47:00  2019-01-01   00  2019-01-01-00  "
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -918,7 +956,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -1053,7 +1091,7 @@
        "4  00091,5,W,N  001609,5,N,5  10106,5 2019-01-01 04:52:00  2019-01-01   04  "
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1068,14 +1106,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "nb moments for stations measures : 29774\n"
+      "nb moments for stations measures : 8784\n"
      ]
     }
    ],
@@ -1087,15 +1125,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "nb ground station measurement after : 243781\n",
-      "nb ground station measurement before : 243781\n",
+      "nb ground station measurement after : 152624\n",
+      "nb ground station measurement before : 152624\n",
       "***\n"
      ]
     }
@@ -1115,7 +1153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1327,7 +1365,7 @@
        "[5 rows x 30 columns]"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1338,47 +1376,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'new_df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-2-ae90cc444fa1>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mdf\u001b[0m \u001b[0;34m=\u001b[0m\u001b[0mnew_df\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mdf\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"Temperature\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSeries\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTemperature\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreplace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'\\+'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m''\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mregex\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreplace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m','\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'.'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mregex\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mapply\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mto_numeric\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'coerce'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0mdf\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"Dew\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSeries\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mDew\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreplace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'\\+'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m''\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mregex\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreplace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m','\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'.'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mregex\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mapply\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mto_numeric\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'coerce'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mdf\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"ATM\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSeries\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mATM\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreplace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'\\+'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m''\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mregex\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreplace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m','\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'.'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mregex\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mapply\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mto_numeric\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'coerce'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'new_df' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df =new_df\n",
     "\n",
     "df[\"Temperature\"]=pd.Series(df.Temperature).replace('\\+', '', regex=True).replace(',', '.', regex=True).apply(pd.to_numeric, args=('coerce',))\n",
     "df[\"Dew\"]=pd.Series(df.Dew).replace('\\+', '', regex=True).replace(',', '.', regex=True).apply(pd.to_numeric, args=('coerce',))\n",
     "df[\"ATM\"]=pd.Series(df.ATM).replace('\\+', '', regex=True).replace(',', '.', regex=True).apply(pd.to_numeric, args=('coerce',))\n",
-    "\n",
-    "# Simplify column names for stations\n",
-    "columns = {\"Population\":\"population\", \"Dist-MRoads\":\"dist-mroads\", \"Dist-Setl\":\"dist-setl\", \"Dist-Coast\":\"dist-coast\", \"Dist-Forest\":\"dist-forest\", \"Slope\":\"slope\", \"Elevation\":\"elevation\", \"DATE\":\"date\", \"Temperature\":\"TEMP\", \"Wind\":\"WIND\", \"Dew\":\"DEW\", \"Sky\":\"SKY\", \"Visibility\":\"VIS\"}\n",
-    "df = df.rename(columns=columns)\n",
-    "df = df.replace('14th & S ST NW  B (undefined) (38.913805 -77.03275) Primary 60_minute_average 01_01_2019 01_01_2020.csv', '14th & S ST NW B')\n",
-    "df = df.replace('14th & S ST NW  (outside) (38.913805 -77.03275) Primary 60_minute_average 01_01_2019 01_01_2020.csv', '14th & S ST NW A')\n",
-    "df = df.replace('V Street (outside) (38.918491 -77.037393) Primary 60_minute_average 01_01_2019 01_01_2020.csv', 'V Street')\n",
-    "df = df.replace('McMillan 1 (outside) (38.92185 -77.013271) Primary 60_minute_average 01_01_2019 01_01_2020.csv', 'McMillan 1')\n",
-    "df = df.replace('Courthouse  (outside) (38.88812 -77.088094) Primary 60_minute_average 01_01_2019 01_01_2020.csv', 'Courthouse')\n",
-    "df = df.replace('Cheverly (outside) (38.921633 -76.921768) Primary 60_minute_average 01_01_2019 01_01_2020-9.csv', 'Cheverly 9')\n",
-    "df = df.replace('Cheverly (outside) (38.921633 -76.921768) Primary 60_minute_average 01_01_2019 01_01_2020-1.csv', 'Cheverly 1')\n",
-    "df = df.replace('arlington (outside) (38.900099 -77.081078) Primary 60_minute_average 01_01_2019 01_01_2020-1.csv', 'Arlington')\n",
-    "df = df.replace('13th and E St SE B (undefined) (38.882974 -76.988037) Primary 60_minute_average 01_01_2019 01_01_2020.csv', '13th & E ST SE B')\n",
-    "df = df.replace('13th and E St SE (outside) (38.882974 -76.988037) Primary 60_minute_average 01_01_2019 01_01_2020.csv', '13th & E ST SE A')\n"
+    "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "metadata": {
     "scrolled": true
    },
@@ -1585,7 +1597,7 @@
        "[5 rows x 30 columns]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1612,7 +1624,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1638,12 +1650,256 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
     "df.to_csv(\"bigtable.csv\", index=False)"
-
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count    152418.000000\n",
+       "mean         36.487491\n",
+       "std          48.151102\n",
+       "min           0.000000\n",
+       "25%           0.367146\n",
+       "50%          12.529437\n",
+       "75%          54.049690\n",
+       "max         181.214554\n",
+       "Name: population, dtype: float64"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[\"population\"].describe()\n",
+    "#df[df[\"population\"] == None].head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Unnamed: 0</th>\n",
+       "      <th>datetime</th>\n",
+       "      <th>pm25</th>\n",
+       "      <th>type</th>\n",
+       "      <th>sensor</th>\n",
+       "      <th>station_id</th>\n",
+       "      <th>x</th>\n",
+       "      <th>y</th>\n",
+       "      <th>population</th>\n",
+       "      <th>dist-mroads</th>\n",
+       "      <th>...</th>\n",
+       "      <th>date</th>\n",
+       "      <th>24hr</th>\n",
+       "      <th>datehour</th>\n",
+       "      <th>date</th>\n",
+       "      <th>TEMP</th>\n",
+       "      <th>WIND</th>\n",
+       "      <th>DEW</th>\n",
+       "      <th>SKY</th>\n",
+       "      <th>VIS</th>\n",
+       "      <th>ATM</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>9669</th>\n",
+       "      <td>9669</td>\n",
+       "      <td>2019-01-11 02:00:00 UTC</td>\n",
+       "      <td>11.25</td>\n",
+       "      <td>PurpleAir</td>\n",
+       "      <td>B</td>\n",
+       "      <td>13th &amp; E ST SE B</td>\n",
+       "      <td>38.882974</td>\n",
+       "      <td>-76.988037</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.118</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2019-01-11</td>\n",
+       "      <td>02:00:00</td>\n",
+       "      <td>2019-01-11-02</td>\n",
+       "      <td>2019-01-11T02:52:00</td>\n",
+       "      <td>-6.5</td>\n",
+       "      <td>46</td>\n",
+       "      <td>-106.5</td>\n",
+       "      <td>22000</td>\n",
+       "      <td>16093</td>\n",
+       "      <td>10216.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9670</th>\n",
+       "      <td>9670</td>\n",
+       "      <td>2019-01-11 03:00:00 UTC</td>\n",
+       "      <td>9.10</td>\n",
+       "      <td>PurpleAir</td>\n",
+       "      <td>B</td>\n",
+       "      <td>13th &amp; E ST SE B</td>\n",
+       "      <td>38.882974</td>\n",
+       "      <td>-76.988037</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.118</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2019-01-11</td>\n",
+       "      <td>03:00:00</td>\n",
+       "      <td>2019-01-11-03</td>\n",
+       "      <td>2019-01-11T03:00:00</td>\n",
+       "      <td>-6.1</td>\n",
+       "      <td>46</td>\n",
+       "      <td>-106.1</td>\n",
+       "      <td>99999</td>\n",
+       "      <td>16000</td>\n",
+       "      <td>10216.1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9671</th>\n",
+       "      <td>9671</td>\n",
+       "      <td>2019-01-11 04:00:00 UTC</td>\n",
+       "      <td>5.94</td>\n",
+       "      <td>PurpleAir</td>\n",
+       "      <td>B</td>\n",
+       "      <td>13th &amp; E ST SE B</td>\n",
+       "      <td>38.882974</td>\n",
+       "      <td>-76.988037</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.118</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2019-01-11</td>\n",
+       "      <td>04:00:00</td>\n",
+       "      <td>2019-01-11-04</td>\n",
+       "      <td>2019-01-11T04:52:00</td>\n",
+       "      <td>-11.5</td>\n",
+       "      <td>46</td>\n",
+       "      <td>-106.5</td>\n",
+       "      <td>22000</td>\n",
+       "      <td>16093</td>\n",
+       "      <td>10221.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9672</th>\n",
+       "      <td>9672</td>\n",
+       "      <td>2019-01-11 05:00:00 UTC</td>\n",
+       "      <td>6.30</td>\n",
+       "      <td>PurpleAir</td>\n",
+       "      <td>B</td>\n",
+       "      <td>13th &amp; E ST SE B</td>\n",
+       "      <td>38.882974</td>\n",
+       "      <td>-76.988037</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.118</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2019-01-11</td>\n",
+       "      <td>05:00:00</td>\n",
+       "      <td>2019-01-11-05</td>\n",
+       "      <td>2019-01-11T05:52:00</td>\n",
+       "      <td>-11.5</td>\n",
+       "      <td>67</td>\n",
+       "      <td>-106.5</td>\n",
+       "      <td>22000</td>\n",
+       "      <td>16093</td>\n",
+       "      <td>10224.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9673</th>\n",
+       "      <td>9673</td>\n",
+       "      <td>2019-01-11 06:00:00 UTC</td>\n",
+       "      <td>5.26</td>\n",
+       "      <td>PurpleAir</td>\n",
+       "      <td>B</td>\n",
+       "      <td>13th &amp; E ST SE B</td>\n",
+       "      <td>38.882974</td>\n",
+       "      <td>-76.988037</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.118</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2019-01-11</td>\n",
+       "      <td>06:00:00</td>\n",
+       "      <td>2019-01-11-06</td>\n",
+       "      <td>2019-01-11T06:00:00</td>\n",
+       "      <td>-11.1</td>\n",
+       "      <td>67</td>\n",
+       "      <td>-106.1</td>\n",
+       "      <td>99999</td>\n",
+       "      <td>16000</td>\n",
+       "      <td>10224.1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 30 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      Unnamed: 0                 datetime   pm25       type sensor  \\\n",
+       "9669        9669  2019-01-11 02:00:00 UTC  11.25  PurpleAir      B   \n",
+       "9670        9670  2019-01-11 03:00:00 UTC   9.10  PurpleAir      B   \n",
+       "9671        9671  2019-01-11 04:00:00 UTC   5.94  PurpleAir      B   \n",
+       "9672        9672  2019-01-11 05:00:00 UTC   6.30  PurpleAir      B   \n",
+       "9673        9673  2019-01-11 06:00:00 UTC   5.26  PurpleAir      B   \n",
+       "\n",
+       "            station_id          x          y  population  dist-mroads  ...  \\\n",
+       "9669  13th & E ST SE B  38.882974 -76.988037         0.0        0.118  ...   \n",
+       "9670  13th & E ST SE B  38.882974 -76.988037         0.0        0.118  ...   \n",
+       "9671  13th & E ST SE B  38.882974 -76.988037         0.0        0.118  ...   \n",
+       "9672  13th & E ST SE B  38.882974 -76.988037         0.0        0.118  ...   \n",
+       "9673  13th & E ST SE B  38.882974 -76.988037         0.0        0.118  ...   \n",
+       "\n",
+       "            date      24hr       datehour                 date  TEMP  WIND  \\\n",
+       "9669  2019-01-11  02:00:00  2019-01-11-02  2019-01-11T02:52:00  -6.5    46   \n",
+       "9670  2019-01-11  03:00:00  2019-01-11-03  2019-01-11T03:00:00  -6.1    46   \n",
+       "9671  2019-01-11  04:00:00  2019-01-11-04  2019-01-11T04:52:00 -11.5    46   \n",
+       "9672  2019-01-11  05:00:00  2019-01-11-05  2019-01-11T05:52:00 -11.5    67   \n",
+       "9673  2019-01-11  06:00:00  2019-01-11-06  2019-01-11T06:00:00 -11.1    67   \n",
+       "\n",
+       "        DEW    SKY    VIS      ATM  \n",
+       "9669 -106.5  22000  16093  10216.5  \n",
+       "9670 -106.1  99999  16000  10216.1  \n",
+       "9671 -106.5  22000  16093  10221.5  \n",
+       "9672 -106.5  22000  16093  10224.5  \n",
+       "9673 -106.1  99999  16000  10224.1  \n",
+       "\n",
+       "[5 rows x 30 columns]"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[df[\"population\"] == 0].head()"
    ]
   },
   {
@@ -1670,7 +1926,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
some openAQ records were missing wordpop feature values 
It was indirect effect causing because worldpop works only for year 2019 (there is a poetential tiff by year)
